### PR TITLE
Remove callback from model.getData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koopjs/provider-file-geojson",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koopjs/provider-file-geojson",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-extra": "^11.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koopjs/provider-file-geojson",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Simple provider for serving file-based GeoJSON",
   "main": "index.js",
   "scripts": {

--- a/src/model.js
+++ b/src/model.js
@@ -16,7 +16,7 @@ class Model {
     this.#verifyDataDirectoryExists(this.#dataDirPath);
   }
 
-  async getData (req, callback) {
+  async getData (req) {
     const filePath = await this.#getFileName(req.params.id);
     const filename = path.basename(filePath);
     
@@ -30,10 +30,10 @@ class Model {
       metadata.name = metadata.name || filename;
       metadata.description = metadata.description || `GeoJSON from ${filename}`;
       geojson.metadata = metadata;
-      return callback(null, geojson);
+      return geojson;
     } catch (err) {
       err.message = `${loggingPrefix}${err.message}`;
-      callback(err);
+      throw err;
     }
   }
 

--- a/src/model.spec.js
+++ b/src/model.spec.js
@@ -10,8 +10,6 @@ const fakeKoop = {
   logger: mockLogger,
 };
 
-const { promisify } = require('util');
-
 describe('Model class', () => {
   describe('constructor', () => {
     test('sets options', async () => {
@@ -48,8 +46,7 @@ describe('Model class', () => {
         ttl: 99,
       });
 
-      const getData = promisify(model.getData).bind(model);
-      const geojson = await getData({ params: { id: 'point-fc' } });
+      const geojson = await model.getData({ params: { id: 'point-fc' } });
       expect(geojson).toEqual({
         features: [
           {
@@ -75,8 +72,7 @@ describe('Model class', () => {
         ttl: 99,
       });
 
-      const getData = promisify(model.getData).bind(model);
-      const geojson = await getData({ params: { id: 'point-fc' } });
+      const geojson = await model.getData({ params: { id: 'point-fc' } });
       expect(geojson).toEqual({
         features: [
           {
@@ -102,8 +98,7 @@ describe('Model class', () => {
         ttl: 99,
       });
 
-      const getData = promisify(model.getData).bind(model);
-      const geojson = await getData({ params: { id: 'point-f' } });
+      const geojson = await model.getData({ params: { id: 'point-f' } });
       expect(geojson).toEqual({
         features: [
           {
@@ -132,8 +127,7 @@ describe('Model class', () => {
         ttl: 99,
       });
 
-      const getData = promisify(model.getData).bind(model);
-      const geojson = await getData({ params: { id: 'point' } });
+      const geojson = await model.getData({ params: { id: 'point' } });
       expect(geojson).toEqual({
         features: [
           {
@@ -162,10 +156,8 @@ describe('Model class', () => {
         ttl: 99,
       });
 
-      const getData = promisify(model.getData).bind(model);
-
       try {
-        await getData({ params: { id: 'foo' } });
+        await model.getData({ params: { id: 'foo' } });
         throw new Error('should have thrown');
       } catch (error) {
         expect(error.message).toEqual(
@@ -185,10 +177,8 @@ describe('Model class', () => {
         ttl: 99,
       });
 
-      const getData = promisify(model.getData).bind(model);
-
       try {
-        await getData({ params: { id: 'point-fc' } });
+        await model.getData({ params: { id: 'point-fc' } });
         throw new Error('should have thrown');
       } catch (error) {
         expect(error.message).toEqual('File GeoJSON provider: cannot read');
@@ -196,7 +186,7 @@ describe('Model class', () => {
       }
     });
 
-    test('500s if unparseable JSON', async () => {
+    test('500s if unparsable JSON', async () => {
       fs.readFile.mockImplementationOnce(() => {
         return 'not-json';
       });
@@ -206,10 +196,8 @@ describe('Model class', () => {
         ttl: 99,
       });
 
-      const getData = promisify(model.getData).bind(model);
-
       try {
-        await getData({ params: { id: 'point-fc' } });
+        await model.getData({ params: { id: 'point-fc' } });
         throw new Error('should have thrown');
       } catch (error) {
         expect(error.message).toEqual(


### PR DESCRIPTION
> [DEP0174] DeprecationWarning: Calling promisify on a function that returns a Promise is likely a mistake.

The above warning is present when running on node v22, but not on node v20.

Since this could be a breaking change setups expecting a callback, I've incremented the minor version (to 2.3.0).